### PR TITLE
Channel name is displayed as ID

### DIFF
--- a/scripts/timeline.coffee
+++ b/scripts/timeline.coffee
@@ -14,6 +14,7 @@ request = require 'request'
 module.exports = (robot) ->
   robot.hear /.*?/i, (msg) ->
     channel = msg.envelope.room
+    room_name = robot.adapter.client.rtm.dataStore.getChannelGroupOrDMById(channel).name
     message = msg.message.text
     username = msg.message.user.name
     user_id = msg.message.user.id
@@ -23,7 +24,7 @@ module.exports = (robot) ->
       message = encodeURIComponent(message)
       link_names = if process.env.SLACK_LINK_NAMES then process.env.SLACK_LINK_NAMES else 0
       timeline_channel = if process.env.SLACK_TIMELINE_CHANNEL then process.env.SLACK_TIMELINE_CHANNEL else 'timeline'
-      request = msg.http("https://slack.com/api/chat.postMessage?token=#{process.env.SLACK_API_TOKEN}&channel=%23#{timeline_channel}&text=#{message}%20(at%20%23#{channel}%20)&username=#{username}&link_names=#{link_names}&pretty=1&icon_url=#{user_image}").get()
+      request = msg.http("https://slack.com/api/chat.postMessage?token=#{process.env.SLACK_API_TOKEN}&channel=%23#{timeline_channel}&text=#{message}%20(at%20%23#{room_name}%20)&username=#{username}&link_names=#{link_names}&pretty=1&icon_url=#{user_image}").get()
       request (err, res, body) ->
 
   reloadUserImages = (robot, user_id) ->
@@ -45,5 +46,3 @@ module.exports = (robot) ->
         image = json.members[i].profile.image_48
         robot.brain.data.userImages[json.members[i].id] = image
         ++i
-
-


### PR DESCRIPTION
## 🚨Issue

The Hubot-Slack API has been updated from v3 to v4
Along with that, the channel name has been changed to channel ID and it no longer appears correctly

For that reason, hubot-slack-timeline will display `(at # {channel name})` as `(at # {channel ID}` `, so we need to fix it.

## :mortar_board: Solution Plan

Added what can be converted from channel ID to room name

## Screenshot

![](https://user-images.githubusercontent.com/19791597/39358398-e35f09d4-4a50-11e8-8656-7766a85fbdd9.png)
